### PR TITLE
support minimum PHP 7.2 and illuminate 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
         "email": "arifin@mamiteam.com"
     }],
     "require": {
-        "php": "^7.1",
-        "illuminate/queue": "^5.7",
-        "illuminate/support": "^5.7"
+        "php": "^7.2",
+        "illuminate/queue": "^6.0",
+        "illuminate/support": "^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
bump package version requirement to support Laravel 6
bump PHP to 7.2 because Laravel 6 requires minimum PHP 7.2