### PR TITLE
feat: add sleep time config for lower message receive

### DIFF
--- a/src/SqsDistributedQueue.php
+++ b/src/SqsDistributedQueue.php
@@ -50,7 +50,7 @@ class SqsDistributedQueue extends SqsQueue
                     $this->messageBuffer = $response['Messages'];
                 }
             } else {
-                $this->sleep();
+                $this->shouldSleep = true;
             }
         }
 

--- a/src/SqsDistributedQueue.php
+++ b/src/SqsDistributedQueue.php
@@ -34,9 +34,11 @@ class SqsDistributedQueue extends SqsQueue
             $this->logSqsResponse($response);
 
             if (! is_null($response['Messages']) && count($response['Messages']) > 0) {
-                $this->shouldSleep = count($response['Messages']) < $maxReceiveMessage;
+                $messagesCount = count($response['Messages']);
 
-                if (count($response['Messages']) === 1) {
+                $this->shouldSleep = $messagesCount < $maxReceiveMessage;
+
+                if ($messagesCount === 1) {
                     return new SqsDistributedJob(
                         $this->container,
                         $this->sqs,
@@ -128,8 +130,9 @@ class SqsDistributedQueue extends SqsQueue
     private function sleep()
     {
         $sleepTime = $this->getSleepTime();
+        $maxReceiveMessage = $this->getMaxReceiveMessage();
 
-        if ($sleepTime > 0) {
+        if ($sleepTime > 0 && $maxReceiveMessage > 1) {
             info(sprintf('Sleeping for %d seconds.', $sleepTime));
             sleep($sleepTime);
         }


### PR DESCRIPTION
Resolve https://github.com/mamitech/laravel-sqs-subscriber/issues/5

- adding `sleep_time` based on config.
- call `sleep` when the received messages count is less than the expectation (maxReceiveMessage)

preview
```
max_receive_message=10
sleep_time=40
```

<img width="722" alt="Screenshot 2025-02-18 at 3 45 34 PM" src="https://github.com/user-attachments/assets/54bf2e61-c691-4ba2-a423-30ed9d60da6c" />
