### PR TITLE
Add ability to set custom parameter names for message topic and body

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,10 +97,11 @@ return [
 
         ...
 ```
-note that in the new connection you will use `sqs-distributed` as driver value. To keep the consistency
+Note that in the new connection you will use `sqs-distributed` as driver value. To keep the consistency
 we also name the connection as `sqs-distributed` as the name of it's driver. You can also
 specify the default queue inside `queue` key that will be used when you don't specify particular
-queue to listen to.
+queue to listen to. And if your message usees different key names for topic and body, you can specify
+it using `topic_name` and `body_name` keys.
 
 ## Map Topic to Handler Class in `config/sqs-topic-map.php`
 

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ AWS_SQS_MAX_RECEIVE_MESSAGE=1
 AWS_SQS_DISTRIBUTED_DEFAULT_QUEUE=test-local
 AWS_SQS_DISTRIBUTED_USE_TOPIC=true
 AWS_SQS_DISTRIBUTED_TOPIC_NAME=topic
+AWS_SQS_DISTRIBUTED_BODY_NAME=message
 ```
 
 ## Troubleshoot
@@ -89,7 +90,8 @@ return [
             'secret' => env('AWS_SECRET_ACCESS_KEY', 'your-secret-key'),
             'prefix' => env('AWS_SQS_PREFIX', 'https://sqs.us-east-1.amazonaws.com/your-account-id'),
             'queue' => env('AWS_SQS_DISTRIBUTED_DEFAULT_QUEUE', 'user-registration'),
-            'topic_name' => env('AWS_SQS_DISTRIBUTED_TOPIC_NAME', 'user-registration'),
+            'topic_name' => env('AWS_SQS_DISTRIBUTED_TOPIC_NAME', 'topic'),
+            'body_name' => env('AWS_SQS_DISTRIBUTED_BODY_NAME', 'message'),
             'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
         ],
 

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ AWS_SQS_PREFIX=https://sqs.ap-southeast-1.amazonaws.com/your-account-id
 AWS_SQS_MAX_RECEIVE_MESSAGE=1
 AWS_SQS_DISTRIBUTED_DEFAULT_QUEUE=test-local
 AWS_SQS_DISTRIBUTED_USE_TOPIC=true
+AWS_SQS_DISTRIBUTED_TOPIC_NAME=topic
 ```
 
 ## Troubleshoot
@@ -88,6 +89,7 @@ return [
             'secret' => env('AWS_SECRET_ACCESS_KEY', 'your-secret-key'),
             'prefix' => env('AWS_SQS_PREFIX', 'https://sqs.us-east-1.amazonaws.com/your-account-id'),
             'queue' => env('AWS_SQS_DISTRIBUTED_DEFAULT_QUEUE', 'user-registration'),
+            'topic_name' => env('AWS_SQS_DISTRIBUTED_TOPIC_NAME', 'user-registration'),
             'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
         ],
 

--- a/src/SqsDistributedJob.php
+++ b/src/SqsDistributedJob.php
@@ -52,19 +52,29 @@ class SqsDistributedJob extends SqsJob
         }
 
         # topic key have higher priority to be used
-        if (isset($payload['topic'])) {
-            $topic = $payload['topic'];
+        $topicName = $this->getTopicName();
+        if (isset($payload[$topicName])) {
+            $topic = $payload[$topicName];
         }
 
         return $topic;
     }
 
+    private function getTopicName()
+    {
+        return config(sprintf('queue.connections.%s.topic_name', $this->getQueueName()), 'topic');
+    }
+
+    private function getQueueName()
+    {
+        return str_replace('/', '', $this->queue);
+    }
+
     protected function getListener(string $topic)
     {
-        $queue = str_replace('/', '', $this->queue);
-        $listenerClass = config("sqs-topic-map.$queue.$topic");
+        $listenerClass = config(sprintf('sqs-topic-map.%s.%s', $this->getQueueName(), $topic));
         if (empty($listenerClass)) {
-            throw new \Exception("Listener for topic $topic is not found");
+            throw new \Exception(sprintf('Listener for topic %s is not found', $topic));
         }
 
         return $listenerClass;

--- a/src/SqsDistributedJob.php
+++ b/src/SqsDistributedJob.php
@@ -7,9 +7,10 @@ class SqsDistributedJob extends SqsJob
 {
     public function fire()
     {
+        $bodyName = $this->getBodyName();
         $payload = $this->payload();
         $listener = app()->make($payload['job']);
-        $listener->handle($this->isUseTopic() ? $payload['message'] : $payload);
+        $listener->handle($this->isUseTopic() ? $payload[$bodyName] : $payload);
 
         if (! $this->isDeletedOrReleased()) {
             if ($this->getMaxReceiveMessage() === 1) {
@@ -63,6 +64,11 @@ class SqsDistributedJob extends SqsJob
     private function getTopicName()
     {
         return config(sprintf('queue.connections.%s.topic_name', $this->getConnectionName()));
+    }
+
+    private function getBodyName()
+    {
+        return config(sprintf('queue.connections.%s.body_name', $this->getConnectionName()));
     }
 
     private function getQueueName()


### PR DESCRIPTION
With fixed names for the message topic and body parameter, it might not be possible to process messages dispatched by third party systems, like Symfony. With this update the flexibility for doing that is added. You just have to add
```
AWS_SQS_DISTRIBUTED_TOPIC_NAME=my_custom_topic
AWS_SQS_DISTRIBUTED_BODY_NAME=my_custom_body
```
to your `.env` file, and also
```
'topic_name' => env('AWS_SQS_DISTRIBUTED_TOPIC_NAME', 'topic'),
'body_name' => env('AWS_SQS_DISTRIBUTED_BODY_NAME', 'message'),
```
to the `queue.php` file, and you´re good to go.